### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's a bunch of information related to the programming of the Music Matrix Com
 
 The data of the program is stored in an array of objects. the array is called "song" so if you type that into the console of your webpage, you will be able to see the data representation of the song that you are making. Not particularly useful for compositing but quite useful if you want to see if the changes you made worked. 
 
-The audio is generated via a scale which is saved as a part of each tracks's "scale" parameter. Each virtcal line of notes is stored in the long array of each track. The notes are stored as "T|x|" where |x| is a number between 1 and 16 and each T|x| referencing to a note in the scale. the number is the note the midi note that corrisponds to the number in accordance with General Midi Standard : https://en.wikipedia.org/wiki/General_MIDI and is played through the Midi.JS plugin
+The audio is generated via a scale which is saved as a part of each tracks's "scale" parameter. Each virtcal line of notes is stored in the long array of each track. The notes are stored as "T|x|" where |x| is a number between 1 and 16 and each T|x| referencing to a note in the scale. the number is the note the midi note that corresponds to the number in accordance with General Midi Standard : https://en.wikipedia.org/wiki/General_MIDI and is played through the Midi.JS plugin
 
 The presets array is where I keep all the presets that any user can use. They are in a somewhat arbiturary order. The only exception is that the Music Matrix cords should always be kept at the top. 
 


### PR DESCRIPTION
@muggy8, I've corrected a typographical error in the documentation of the [Music-Matrix-Composer](https://github.com/muggy8/Music-Matrix-Composer) project. Specifically, I've changed corrispond to correspond. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
